### PR TITLE
Fix Sitemap Link in robots.txt

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
         host: 'https://wayfair.github.io',
-        sitemap: 'https://wayfair.github.io/sitemap.xml',
+        sitemap: 'https://wayfair.github.io/sitemap/sitemap-index.xml',
         policy: [{ userAgent: '*', allow: '/' }]
       }
     },


### PR DESCRIPTION
Robots.txt working: https://wayfair.github.io/robots.txt
Current Sitemap: https://wayfair.github.io/sitemap.xml 404s
Sitemap Plugin puts it in a subfolder and creates a sitemap index file:
https://github.com/wayfair/wayfair.github.io/blob/gh-pages/sitemap/sitemap-index.xml
Working Link: https://wayfair.github.io/sitemap/sitemap-index.xml