### PR TITLE
Linked to the github page of buildkite

### DIFF
--- a/src/components/Supported/index.js
+++ b/src/components/Supported/index.js
@@ -52,7 +52,7 @@ const Supported = () => (
         </a>
       </Col>
       <Col lg="3" sm="6">
-        <a href="https://buildkite.com/">
+        <a href="https://github.com/buildkite">
           <StaticImage
             className="d-none d-md-inline-flex"
             src="../../images/supported/Buildkite.png"


### PR DESCRIPTION
IMHO we should link to the open source listing rather than linking to the product website