### PR TITLE
Update Image Cards with Nested Docs Links

### DIFF
--- a/src/components/ImageCards/index.js
+++ b/src/components/ImageCards/index.js
@@ -12,7 +12,7 @@ const cards = [
     title: "Open Source Platform",
     description:
       "The heart and foundation of our open source offerings. For Wayfair and beyond.",
-    href: "/docs/ospo-platform/",
+    href: "/docs/ospo/platform/",
     linkText: "Take a look",
     imageSrc: PlatformImage,
     alt: "Open Source Platform Background Image",
@@ -21,7 +21,7 @@ const cards = [
     title: "Developer Advocacy",
     description:
       "Serving the community through our catalogue of open source projects.",
-    href: "/docs/ospo-advocacy/",
+    href: "/docs/ospo/advocacy/",
     linkText: "Watch and Learn",
     imageSrc: DevAdvocateImage,
     alt: "Developer Advocacy Background Image",
@@ -30,7 +30,7 @@ const cards = [
     title: "Auxiliary Engineering",
     description:
       "Driving continuous learning and cultural change through open source.",
-    href: "/docs/ospo-aux-eng/",
+    href: "/docs/ospo/aux-eng/",
     linkText: "Find out more",
     imageSrc: AuxEngImage,
     alt: "Open Source Platform Background Image",


### PR DESCRIPTION
Fixes the links in these image cards on the index to match the new nested structure:
![image](https://user-images.githubusercontent.com/8042502/160142046-ff710bba-87c1-41e1-b071-da4bb90aae32.png)
