### PR TITLE
google analytics, even though it was gtag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,10 +21,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-gdpr-cookies`,
       options: {
-        googleTagManager: {
+        googleAnalytics: {
           trackingId: 'G-WDNGECESR2', // leave empty if you want to disable the tracker
-          cookieName: 'gatsby-gdpr-google-tagmanager', // default
-          dataLayerName: 'dataLayer', // default
+          cookieName: 'gatsby-gdpr-google-analytics', // default
+          anonymize: true, // default
+          allowAdFeatures: false // default
         },
         environments: ['production']
       },

--- a/src/components/cookiebanner.js
+++ b/src/components/cookiebanner.js
@@ -4,7 +4,7 @@ import { withCookies } from 'react-cookie'
 
 const CookieBanner = ({ cookies }) => {    
     const setCookies = (cookiesBool) => {
-        cookies.set('gatsby-gdpr-google-tagmanager', cookiesBool) // so named to allow
+        cookies.set('gatsby-gdpr-google-analytics', cookiesBool) // so named to allow
     }
 
     const onKeyDown = (event, cookies) => {
@@ -18,7 +18,7 @@ const CookieBanner = ({ cookies }) => {
         }
     }
 
-    return (typeof cookies.get('gatsby-gdpr-google-tagmanager') == 'undefined') ? (
+    return (typeof cookies.get('gatsby-gdpr-google-analytics') == 'undefined') ? (
         <Container
             fluid
             style={{


### PR DESCRIPTION
i've switched over to using google analytics directly -- it seems like that's what "gtag" configuration was doing in the previous plugin. Gatsby is a little to helpful obfuscating these details :)